### PR TITLE
Fix typos, correct Redis dev port, and improve health unit test

### DIFF
--- a/src/FacadeCompanyName.FacadeProjectName.DomainService/Folders/IAppFolders.cs
+++ b/src/FacadeCompanyName.FacadeProjectName.DomainService/Folders/IAppFolders.cs
@@ -3,7 +3,7 @@
     public interface IAppFolders
     {
         /// <summary>
-        /// 临时文件下载文件夹 /temps//downloads/
+        /// 临时文件下载文件夹 /temps/downloads/
         /// </summary>
         string TempFileDownloadFolder { get; }
         /// <summary>

--- a/src/FacadeCompanyName.FacadeProjectName.MySql/EntityFrameworkCore/FacadeProjectNameMySqlDbContext.cs
+++ b/src/FacadeCompanyName.FacadeProjectName.MySql/EntityFrameworkCore/FacadeProjectNameMySqlDbContext.cs
@@ -5,7 +5,7 @@ namespace FacadeCompanyName.FacadeProjectName.MySql.EntityFrameworkCore
 {
     public class FacadeProjectNameMySqlDbContext : MySqlDbContext
     {
-        // 配置 DbSet 自动注册 ef core IRepotory 
+        // 配置 DbSet 自动注册 ef core IRepository 
 
 
         public FacadeProjectNameMySqlDbContext(DbContextOptions<FacadeProjectNameMySqlDbContext> options)

--- a/src/FacadeCompanyName.FacadeProjectName.Oracle/EntityFrameworkCore/FacadeProjectNameOracleDbContext.cs
+++ b/src/FacadeCompanyName.FacadeProjectName.Oracle/EntityFrameworkCore/FacadeProjectNameOracleDbContext.cs
@@ -5,7 +5,7 @@ namespace FacadeCompanyName.FacadeProjectName.Oracle.EntityFrameworkCore
 {
     public class FacadeProjectNameOracleDbContext : OracleDbContext
     {
-        // 配置 DbSet 自动注册 ef core IRepotory 
+        // 配置 DbSet 自动注册 ef core IRepository 
 
 
         public FacadeProjectNameOracleDbContext(DbContextOptions<FacadeProjectNameOracleDbContext> options)

--- a/src/FacadeCompanyName.FacadeProjectName.SqlServer/EntityFrameworkCore/FacadeProjectNameSqlServerDbContext.cs
+++ b/src/FacadeCompanyName.FacadeProjectName.SqlServer/EntityFrameworkCore/FacadeProjectNameSqlServerDbContext.cs
@@ -5,7 +5,7 @@ namespace FacadeCompanyName.FacadeProjectName.SqlServer.EntityFrameworkCore
 {
     public class FacadeProjectNameSqlServerDbContext : SqlServerDbContext
     {
-        // 配置 DbSet 自动注册 ef core IRepotory 
+        // 配置 DbSet 自动注册 ef core IRepository 
 
 
         public FacadeProjectNameSqlServerDbContext(DbContextOptions<FacadeProjectNameSqlServerDbContext> options)

--- a/src/FacadeCompanyName.FacadeProjectName.Web.Host/appsettings.Development.json
+++ b/src/FacadeCompanyName.FacadeProjectName.Web.Host/appsettings.Development.json
@@ -26,7 +26,7 @@
   },
   "Redis": {
     "Host": "localhost",
-    "Port": 6079
+    "Port": 6379
   },
   "FacadeConfiguration": {
     "AppName": "FacadeProjectName_Dev"

--- a/test/FacadeCompanyName.FacadeProjectName.Tests/FacadeCompanyName.FacadeProjectName.Tests.csproj
+++ b/test/FacadeCompanyName.FacadeProjectName.Tests/FacadeCompanyName.FacadeProjectName.Tests.csproj
@@ -21,6 +21,7 @@
   <ItemGroup>
     <PackageReference Include="Facade.AspNetCore.TestBase" Version="5.7.0" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.0.1" />
+    <PackageReference Include="Moq" Version="4.20.72" />
     <PackageReference Include="Shouldly" Version="4.3.0" />
     <PackageReference Include="xunit" Version="2.9.3" />
     <PackageReference Include="xunit.runner.visualstudio" Version="3.1.5">

--- a/test/FacadeCompanyName.FacadeProjectName.Tests/Health/HealthApplication_Tests.cs
+++ b/test/FacadeCompanyName.FacadeProjectName.Tests/Health/HealthApplication_Tests.cs
@@ -1,24 +1,40 @@
 ﻿using FacadeCompanyName.FacadeProjectName.Application.Health;
+using FacadeCompanyName.FacadeProjectName.DomainService.Share.App;
+using Moq;
+using Shouldly;
 using System.Threading.Tasks;
 using Xunit;
 namespace FacadeCompanyName.FacadeProjectName.Tests.Health
 {
-    public class HealthApplication_Tests : FacadeProjectNameTestBase
+    public class HealthApplication_Tests
     {
-        private readonly IHealthApplication _healthApplication;
-        public HealthApplication_Tests()
-        {
-            _healthApplication = Resolve<IHealthApplication>();
-        }
-
         [Fact]
         public async Task Check_Test()
         {
+            var oracleRepository = new Mock<IAppOracleRepository>();
+            var sqlServerRepository = new Mock<IAppSqlServerRepository>();
+            var mySqlRepository = new Mock<IAppMySqlRepository>();
+            var expectedTimestamp = "2024-01-01 00:00:00";
+
+            oracleRepository
+                .Setup(repo => repo.ExecuteScalarAsync<string>(It.IsAny<string>(), It.IsAny<object>()))
+                .ReturnsAsync(expectedTimestamp);
+
+            var healthApplication = new HealthApplication(
+                oracleRepository.Object,
+                sqlServerRepository.Object,
+                mySqlRepository.Object);
+
             // Act
-            var output = await _healthApplication.Check();
+            var output = await healthApplication.Check();
 
             // Assert
-            // output.ShouldNotBeNull();
+            output.ShouldBe(expectedTimestamp);
+            oracleRepository.Verify(
+                repo => repo.ExecuteScalarAsync<string>(
+                    It.Is<string>(query => query.Contains("sysdate")),
+                    It.IsAny<object>()),
+                Times.Once);
         }
     }
 }


### PR DESCRIPTION
### Motivation

- Clean up small documentation/comment typos and ensure development config values are correct to avoid confusion during development. 
- Make the health check test deterministic and faster by converting it to a unit test with mocks instead of relying on the IoC test base. 

### Description

- Corrected a spelling error in DbContext comments from `IRepotory` to `IRepository` in the Oracle, MySql, and SqlServer DbContext files. 
- Fixed the temporary download folder comment to `"/temps/downloads/"` in `IAppFolders`. 
- Updated the Redis development port from `6079` to the standard `6379` in `src/FacadeCompanyName.FacadeProjectName.Web.Host/appsettings.Development.json`. 
- Replaced the integration-style health test with a unit test that uses `Moq` to stub `IAppOracleRepository` and `Shouldly` for assertions, and added a `Moq` package reference to the test project. 

### Testing

- Attempted to run the test suite with `dotnet test test/FacadeCompanyName.FacadeProjectName.Tests/FacadeCompanyName.FacadeProjectName.Tests.csproj`, but the command failed because `dotnet` is not available in the execution environment. 
- No other automated tests were run in this environment due to the missing .NET SDK.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6985881edf68832e8015d4089830abae)